### PR TITLE
fix(commit-count): trim git command output

### DIFF
--- a/cmd/crossplanereleaser/main.go
+++ b/cmd/crossplanereleaser/main.go
@@ -18,7 +18,7 @@ func main() {
 	fs := afero.NewOsFs()
 
 	ctx := kong.Parse(&cli,
-		kong.Name("cnpctl"),
+		kong.Name("crossplanereleaser"),
 		kong.Description("CLI utility to deal with certain tasks around CNP@DBNetz."),
 		kong.BindTo(fs, (*afero.Fs)(nil)),
 	)

--- a/internal/git/git_cli.go
+++ b/internal/git/git_cli.go
@@ -36,7 +36,7 @@ func (g *GitCLIBackend) GetCommitCount(ref Ref) (int, error) {
 	if err != nil {
 		return 0, err
 	}
-	return strconv.Atoi(out)
+	return strconv.Atoi(strings.TrimSpace(out))
 }
 
 func (g *GitCLIBackend) GetTag(ref Ref) (string, error) {


### PR DESCRIPTION
Fix parsing invalid syntax:

cnpctl: error: cannot setup project properties: strconv.Atoi: parsing "267\n": invalid syntax